### PR TITLE
Implement inventory nuking and fix remove all hang

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botw-hundo-dupl",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "homepage": "https://dupl.itntpiston.app/",
   "private": true,
   "dependencies": {

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -31,7 +31,8 @@ ignore_exts = [
     ".webp",
     ".tar.gz",
     ".otf",
-    ".svg"
+    ".svg",
+    ".log"
 ]
 
 ROOT = "."

--- a/src/__tests__/README.md
+++ b/src/__tests__/README.md
@@ -3,7 +3,7 @@
 1. Make up a name for the test
 2. Write the script in simulator
 3. Export the script and put it as `<name>.in.txt` in `src/__tests__`
-4. Write another script that uses `initialize`, `save`, `save as` and `break x slots` to achieve the expected result as the first script (look at one of the existing tests as an example)
+4. Write another script that uses `initialize`, `init gamedata`, `save`, `save as` and `break x slots` to achieve the expected result as the first script (look at one of the existing tests as an example)
 5. Export the new script and put it as `<name>.out.txt` in `src/__tests__`
 6. Create a new file `<name>.e2e.ts`
 7. copy paste the following and replace `<name>` with the name of your test. Replace `YOUR_NAME` with your name

--- a/src/__tests__/aqFinished1.e2e.ts
+++ b/src/__tests__/aqFinished1.e2e.ts
@@ -1,0 +1,7 @@
+
+// Author: iTNTPiston
+const TEST = "aqFinished1";
+it(TEST, ()=>{
+	expect(TEST).toPassE2ESimulation();
+});
+export {};

--- a/src/__tests__/aqFinished1.in.txt
+++ b/src/__tests__/aqFinished1.in.txt
@@ -1,0 +1,78 @@
+# Initialization. At Hateno
+Initialize 2 tree 1 w axe 1 boko spear 1 boko club 1 hammer 1 roy Bow[equip] 11 n*Arrow[equip] 0 AncientArrow 1 pot[equip] 2 Hylianshroom 2 s*pepper 1 amber 2 sunshroom 2 silentshroom 2 ironshroom 2 razorshroom 2 durian 2 Wood 2 rushroom 2 Spring 2 Shaft 2 Screw 1 Core 2 fairy 2 hot frog 1 Slate 8 SpiritOrb 1 Glider
+# Initialization Done
+dnp 2 sunshroom 
+with 2 hylianshroom 2 spicypepper 2 silentshroom 2 ironshroom 2 razorshroom
+Break 5 Slots
+Save
+with 2 wood 2 rushroom 2 ancient spring 2 fairy 2 durian
+Break 5 Slots
+# Regular IST Dupe
+Reload
+with 4 hot frog 1 core
+cook hasty
+Sell 16 orb
+# go to purah get sensor + sensing quest, drop the truffle + extra sun and screw
+Remove 4 screw
+Remove 4 sunshroom
+# Set order
+Drop 2 amber 4 Shaft 1 core
+pickup 2 amber 1 core
+dnp 2 fairy
+pickup 4 Shaft
+# Dump the rest
+Drop 2 durian
+Drop potlid
+# Corruption
+#wb to shop
+# drop all weapon except hammer
+drop 2 weapon 2 tree 1 boko spear 1 boko club 1 w*axe
+Equip hammer
+Save
+# pick up the weapons
+get  2 tree 1 boko spear 1 boko club 1 w*axe
+drop all wood all fairy all rush all amber all a*spring all sunshroom all core all Shaft 1 hasty
+Drop potlid
+unequip hammer
+# go to shrine for autosave
+Save As AutoSave
+drop ro*bow
+Reload
+Shoot 1 arrow
+Save
+Reload AutoSave
+# Drop all except core and shaft
+Drop all wood all fairy all rush all amber all ancient spring 1 hasty
+drop ro*bow
+equip w*axe
+Reload
+Save
+Drop 99 fairy 99 wood
+Reload
+# sell spring for money
+Sell 300 Spring
+Sell 10 amber
+Sell 4 Shaft
+#buy house
+Remove 30 Wood
+# wb to purah get stasis+, bombs+
+remove 3 core
+Remove 3 Shaft
+#Lurelin quests
+get sap
+get 1 seafood pae
+#orbs along the way
+Get 5 orb
+Remove 1 n*arrow
+Drop ro*b
+Drop pot
+Drop hammer
+Drop 5 fairy
+Enter Eventide
+Pickup ro*bow
+add 1 n*arrow
+pickup pot
+pickup 5 fairy
+pickup hammer
+Exit Eventide
+sync gamedata

--- a/src/__tests__/aqFinished1.out.txt
+++ b/src/__tests__/aqFinished1.out.txt
@@ -1,0 +1,6 @@
+initialize 1 hammer[equip] 1 royal bow[equip] 11 normal arrow[equip] 4700 ancient arrow 1 potlid [equip] 999 wood 999 rush 999 Spring 10 amber 1 core 999 fairy 4 Shaft 1 Hasty Elixir[life=1000] 1 slate 1 Glider
+Save
+initialize 1 hammer 2 tree 1 boko spear 1 boko club 1 wood*axe 1 royal bow[equip] 11 normal arrow[equip] 0 ancient arrow 1 slate 1 Glider
+Save as AutoSave
+initialize 1 hammer[equip] 1 royal bow[equip] 1 normal arrow[equip] 10 normal arrow[equip] 4700 ancient arrow 1 potlid [equip] 5 fairy 999 rush 699 Spring 1 Shaft 969 Wood 10 amber 994 fairy 4 Shaft 1 sapphire 1 Hasty Elixir[life=1000] 1 Hasty Elixir[life=1000] 1 seafood paella 1 slate 1 Glider 5 orb 5 orb
+break 10 slots

--- a/src/__tests__/inventoryNuking1.e2e.ts
+++ b/src/__tests__/inventoryNuking1.e2e.ts
@@ -1,0 +1,7 @@
+
+// Author: iTNTPiston
+const TEST = "inventoryNuking1";
+it(TEST, ()=>{
+	expect(TEST).toPassE2ESimulation();
+});
+export {};

--- a/src/__tests__/inventoryNuking1.in.txt
+++ b/src/__tests__/inventoryNuking1.in.txt
@@ -1,0 +1,4 @@
+initialize 1 apple 2 hylianshroom 3 slate
+break 5 slots
+sync gamedata
+save

--- a/src/__tests__/inventoryNuking1.out.txt
+++ b/src/__tests__/inventoryNuking1.out.txt
@@ -1,0 +1,4 @@
+save
+initialize 1 apple 2 hylianshroom 3 slate
+break 5 slots
+sync gamedata

--- a/src/__tests__/inventoryNuking1.out.txt
+++ b/src/__tests__/inventoryNuking1.out.txt
@@ -1,4 +1,4 @@
 save
 initialize 1 apple 2 hylianshroom 3 slate
+init gamedata
 break 5 slots
-sync gamedata

--- a/src/__tests__/inventoryNukingCounterExample.e2e.ts
+++ b/src/__tests__/inventoryNukingCounterExample.e2e.ts
@@ -1,0 +1,7 @@
+
+// Author: iTNTPiston
+const TEST = "inventoryNukingCounterExample";
+it(TEST, ()=>{
+	expect(TEST).toPassE2ESimulation();
+});
+export {};

--- a/src/__tests__/inventoryNukingCounterExample.in.txt
+++ b/src/__tests__/inventoryNukingCounterExample.in.txt
@@ -1,0 +1,8 @@
+initialize 1 apple 2 hylianshroom 1 slate 1 glider
+save
+break 7 slots
+reload
+# inventory not nuked because gamedata not empty
+save
+close game
+reload

--- a/src/__tests__/inventoryNukingCounterExample.out.txt
+++ b/src/__tests__/inventoryNukingCounterExample.out.txt
@@ -1,0 +1,2 @@
+initialize 1 apple 2 hylianshroom 1 slate 1 glider
+save

--- a/src/core/GameData.ts
+++ b/src/core/GameData.ts
@@ -17,7 +17,13 @@ export class GameData implements DisplayableInventory {
 	}
     
 	public syncWith(pouch: VisibleInventory) {
-		this.slots = pouch.getSlots().deepClone();
+		if(pouch.getCount() <=0){
+			// inventory nuking.
+			// when mCount <=0, gamedata is nuked when syncing with pouch
+			this.slots = new Slots([]);
+		}else{
+			this.slots = pouch.getSlots().deepClone();
+		}
 	}
 
 	public updateLife(life: number, slot: number){

--- a/src/core/GameData.ts
+++ b/src/core/GameData.ts
@@ -19,7 +19,8 @@ export class GameData implements DisplayableInventory {
 	public syncWith(pouch: VisibleInventory) {
 		if(pouch.getCount() <=0){
 			// inventory nuking.
-			// when mCount <=0, gamedata is nuked when syncing with pouch
+			// [confirmed] when mCount <=0, gamedata is nuked when syncing with pouch
+			// https://discord.com/channels/269611402854006785/269616041435332608/998326332813480016
 			this.slots = new Slots([]);
 		}else{
 			this.slots = pouch.getSlots().deepClone();

--- a/src/core/SimulationState.ts
+++ b/src/core/SimulationState.ts
@@ -66,6 +66,10 @@ export class SimulationState {
 		this.gameData.syncWith(this.pouch);
 	}
 
+	public setGameData(stacks: ItemStack[]) {
+		this.gameData = new GameData(new Slots([...stacks]));
+	}
+
 	public save(name?: string) {
 		if(name){
 			this.namedSaves[name] = this.gameData.deepClone();

--- a/src/core/Slots.remove.test.ts
+++ b/src/core/Slots.remove.test.ts
@@ -1,0 +1,90 @@
+import { createMaterialStack, ItemStack } from "data/item";
+import { Slots } from "./Slots";
+import { createMaterialMockItem } from "./SlotsTestHelpers";
+
+describe("Slots.remove", ()=>{
+    it("Does nothing if item doesn't exist", ()=>{
+        const mockItem1 = createMaterialMockItem("MaterialA");
+        const stackToRemove = createMaterialStack(mockItem1, 1);
+
+        const stacks: ItemStack[] = [];
+        const slots = new Slots(stacks);
+
+        const removed = slots.remove(stackToRemove, 0);
+        const expected: ItemStack[] = [];
+        expect(removed).toBe(0);
+        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+    });
+    it("Removes item, remove count < stack count", ()=>{
+        const mockItem1 = createMaterialMockItem("MaterialA");
+        const stackToRemove = createMaterialStack(mockItem1, 1);
+
+        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5)];
+        const slots = new Slots(stacks);
+
+        const removed = slots.remove(stackToRemove, 0);
+        const expected: ItemStack[] = [createMaterialStack(mockItem1, 4)];
+        expect(removed).toBe(0);
+        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+    });
+    it("Removes item, remove count = stack count", ()=>{
+        const mockItem1 = createMaterialMockItem("MaterialA");
+        const stackToRemove = createMaterialStack(mockItem1, 5);
+
+        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5)];
+        const slots = new Slots(stacks);
+
+        const removed = slots.remove(stackToRemove, 0);
+        const expected: ItemStack[] = [];
+        expect(removed).toBe(1);
+        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+    });
+    it("Removes item, remove count > stack count", ()=>{
+        const mockItem1 = createMaterialMockItem("MaterialA");
+        const stackToRemove = createMaterialStack(mockItem1, 10);
+
+        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5)];
+        const slots = new Slots(stacks);
+
+        const removed = slots.remove(stackToRemove, 0);
+        const expected: ItemStack[] = [];
+        expect(removed).toBe(1);
+        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+    });
+    it("Removes item from multiple slots", ()=>{
+        const mockItem1 = createMaterialMockItem("MaterialA");
+        const stackToRemove = createMaterialStack(mockItem1, 10);
+
+        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5), createMaterialStack(mockItem1, 5)];
+        const slots = new Slots(stacks);
+
+        const removed = slots.remove(stackToRemove, 0);
+        const expected: ItemStack[] = [];
+        expect(removed).toBe(2);
+        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+    });
+    it("Removes item from slot 1", ()=>{
+        const mockItem1 = createMaterialMockItem("MaterialA");
+        const stackToRemove = createMaterialStack(mockItem1, 10);
+
+        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5), createMaterialStack(mockItem1, 5)];
+        const slots = new Slots(stacks);
+
+        const removed = slots.remove(stackToRemove, 1);
+        const expected: ItemStack[] = [createMaterialStack(mockItem1, 5)];
+        expect(removed).toBe(1);
+        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+    });
+    it("Removes all items with negative count", ()=>{
+        const mockItem1 = createMaterialMockItem("MaterialA");
+        const stackToRemove = createMaterialStack(mockItem1, -1);
+
+        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5), createMaterialStack(mockItem1, 5)];
+        const slots = new Slots(stacks);
+
+        const removed = slots.remove(stackToRemove, 0);
+        const expected: ItemStack[] = [];
+        expect(removed).toBe(2);
+        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+    });
+});

--- a/src/core/Slots.remove.test.ts
+++ b/src/core/Slots.remove.test.ts
@@ -3,88 +3,88 @@ import { Slots } from "./Slots";
 import { createMaterialMockItem } from "./SlotsTestHelpers";
 
 describe("Slots.remove", ()=>{
-    it("Does nothing if item doesn't exist", ()=>{
-        const mockItem1 = createMaterialMockItem("MaterialA");
-        const stackToRemove = createMaterialStack(mockItem1, 1);
+	it("Does nothing if item doesn't exist", ()=>{
+		const mockItem1 = createMaterialMockItem("MaterialA");
+		const stackToRemove = createMaterialStack(mockItem1, 1);
 
-        const stacks: ItemStack[] = [];
-        const slots = new Slots(stacks);
+		const stacks: ItemStack[] = [];
+		const slots = new Slots(stacks);
 
-        const removed = slots.remove(stackToRemove, 0);
-        const expected: ItemStack[] = [];
-        expect(removed).toBe(0);
-        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
-    });
-    it("Removes item, remove count < stack count", ()=>{
-        const mockItem1 = createMaterialMockItem("MaterialA");
-        const stackToRemove = createMaterialStack(mockItem1, 1);
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(0);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes item, remove count < stack count", ()=>{
+		const mockItem1 = createMaterialMockItem("MaterialA");
+		const stackToRemove = createMaterialStack(mockItem1, 1);
 
-        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5)];
-        const slots = new Slots(stacks);
+		const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5)];
+		const slots = new Slots(stacks);
 
-        const removed = slots.remove(stackToRemove, 0);
-        const expected: ItemStack[] = [createMaterialStack(mockItem1, 4)];
-        expect(removed).toBe(0);
-        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
-    });
-    it("Removes item, remove count = stack count", ()=>{
-        const mockItem1 = createMaterialMockItem("MaterialA");
-        const stackToRemove = createMaterialStack(mockItem1, 5);
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [createMaterialStack(mockItem1, 4)];
+		expect(removed).toBe(0);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes item, remove count = stack count", ()=>{
+		const mockItem1 = createMaterialMockItem("MaterialA");
+		const stackToRemove = createMaterialStack(mockItem1, 5);
 
-        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5)];
-        const slots = new Slots(stacks);
+		const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5)];
+		const slots = new Slots(stacks);
 
-        const removed = slots.remove(stackToRemove, 0);
-        const expected: ItemStack[] = [];
-        expect(removed).toBe(1);
-        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
-    });
-    it("Removes item, remove count > stack count", ()=>{
-        const mockItem1 = createMaterialMockItem("MaterialA");
-        const stackToRemove = createMaterialStack(mockItem1, 10);
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(1);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes item, remove count > stack count", ()=>{
+		const mockItem1 = createMaterialMockItem("MaterialA");
+		const stackToRemove = createMaterialStack(mockItem1, 10);
 
-        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5)];
-        const slots = new Slots(stacks);
+		const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5)];
+		const slots = new Slots(stacks);
 
-        const removed = slots.remove(stackToRemove, 0);
-        const expected: ItemStack[] = [];
-        expect(removed).toBe(1);
-        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
-    });
-    it("Removes item from multiple slots", ()=>{
-        const mockItem1 = createMaterialMockItem("MaterialA");
-        const stackToRemove = createMaterialStack(mockItem1, 10);
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(1);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes item from multiple slots", ()=>{
+		const mockItem1 = createMaterialMockItem("MaterialA");
+		const stackToRemove = createMaterialStack(mockItem1, 10);
 
-        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5), createMaterialStack(mockItem1, 5)];
-        const slots = new Slots(stacks);
+		const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5), createMaterialStack(mockItem1, 5)];
+		const slots = new Slots(stacks);
 
-        const removed = slots.remove(stackToRemove, 0);
-        const expected: ItemStack[] = [];
-        expect(removed).toBe(2);
-        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
-    });
-    it("Removes item from slot 1", ()=>{
-        const mockItem1 = createMaterialMockItem("MaterialA");
-        const stackToRemove = createMaterialStack(mockItem1, 10);
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(2);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes item from slot 1", ()=>{
+		const mockItem1 = createMaterialMockItem("MaterialA");
+		const stackToRemove = createMaterialStack(mockItem1, 10);
 
-        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5), createMaterialStack(mockItem1, 5)];
-        const slots = new Slots(stacks);
+		const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5), createMaterialStack(mockItem1, 5)];
+		const slots = new Slots(stacks);
 
-        const removed = slots.remove(stackToRemove, 1);
-        const expected: ItemStack[] = [createMaterialStack(mockItem1, 5)];
-        expect(removed).toBe(1);
-        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
-    });
-    it("Removes all items with negative count", ()=>{
-        const mockItem1 = createMaterialMockItem("MaterialA");
-        const stackToRemove = createMaterialStack(mockItem1, -1);
+		const removed = slots.remove(stackToRemove, 1);
+		const expected: ItemStack[] = [createMaterialStack(mockItem1, 5)];
+		expect(removed).toBe(1);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes all items with negative count", ()=>{
+		const mockItem1 = createMaterialMockItem("MaterialA");
+		const stackToRemove = createMaterialStack(mockItem1, -1);
 
-        const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5), createMaterialStack(mockItem1, 5)];
-        const slots = new Slots(stacks);
+		const stacks: ItemStack[] = [createMaterialStack(mockItem1, 5), createMaterialStack(mockItem1, 5)];
+		const slots = new Slots(stacks);
 
-        const removed = slots.remove(stackToRemove, 0);
-        const expected: ItemStack[] = [];
-        expect(removed).toBe(2);
-        expect(slots.getSlotsRef()).toEqualItemStacks(expected);
-    });
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(2);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
 });

--- a/src/core/Slots.ts
+++ b/src/core/Slots.ts
@@ -65,12 +65,13 @@ export class Slots {
 	// remove item(s) start from slot
 	// return number of slots removed
 	// if item stack can't be matched exactly, will try to match without metadata
+	// pass negative as count to remove all
 	public remove(toRemove: ItemStack, slot: number): number {
 		const oldLength = this.internalSlots.length;
 		let count = toRemove.count;
 		let s = 0;
 		let found = false;
-		for(let i = 0; i<this.internalSlots.length && count > 0;i++){
+		for(let i = 0; i<this.internalSlots.length && count !== 0;i++){
 			const stack = this.internalSlots[i];
 			if(stack.canStack(toRemove)){
 				found = true;
@@ -78,7 +79,7 @@ export class Slots {
 					// find the right slot
 					s++;
 				}else{
-					if(stack.count<count){
+					if(count<0 || stack.count<count){
 						// this stack not enough to remove all
 						count-=stack.count;
 						this.internalSlots[i] = stack.modify({count:0});

--- a/src/core/command/CommandHint.ts
+++ b/src/core/command/CommandHint.ts
@@ -37,6 +37,8 @@ export class CommandHint extends CommandImpl {
 				return "Enter TOTS|Eventide";
 			case "sort":
 				return "Sorting is currently not supported";
+			case "init":
+				return "Init GameData X item1[meta] Y item2[meta] Z item3[meta] ...";
 		}
 		if(isAddVerb(this.keyword)){
 			return "Add item, Add X item1[meta] Y item2[meta] Z item3[meta] ...";

--- a/src/core/command/CommandInitGameData.ts
+++ b/src/core/command/CommandInitGameData.ts
@@ -1,0 +1,19 @@
+import { SimulationState } from "core/SimulationState";
+import { joinItemStackString, processWrappers } from "./helper";
+import { ItemStackCommandWrapper } from "./ItemStackCommandWrapper";
+import { CommandImpl } from "./type";
+
+export class CommandInitGameData extends CommandImpl {
+	private stacks: ItemStackCommandWrapper[];
+	constructor(stacks: ItemStackCommandWrapper[]){
+		super();
+		this.stacks = stacks;
+	}
+
+	public execute(state: SimulationState): void {
+		state.setGameData(processWrappers(this.stacks));
+	}
+	public getDisplayString(): string {
+		return joinItemStackString("Init GameData", this.stacks);
+	}
+}

--- a/src/core/command/Parser.ts
+++ b/src/core/command/Parser.ts
@@ -1,6 +1,7 @@
 import { ItemStack, parseMetadata } from "data/item";
 import { tokenize } from "data/tokenize";
 import { CommandHint } from "./CommandHint";
+import { CommandInitGameData } from "./CommandInitGameData";
 import {  
 	CommandAdd, 
 	CommandBreakSlots, 
@@ -45,12 +46,20 @@ export const parseCommand = (cmdString: string, searchFunc: (word: string)=>Item
 		return result;
 	};
 	// intialize
-	if(tokens.length>1 && keywordMatch(tokens[0],"initialize")){
+	if(tokens.length>0 && keywordMatch(tokens[0],"initialize")){
 		const stacks = parseItemStacks(tokens, 1, searchFunc);
 		if(typeof stacks === "string"){
 			return new CommandNop(cmdString, stacks);
 		}
 		return new CommandInitialize(stacks);
+	}
+	// init gamedata
+	if(tokens.length>1 && keywordMatch(tokens[0],"init") && keywordMatch(tokens[1],"gamedata")){
+		const stacks = parseItemStacks(tokens, 2, searchFunc);
+		if(typeof stacks === "string"){
+			return new CommandNop(cmdString, stacks);
+		}
+		return new CommandInitGameData(stacks);
 	}
 	if(isAddVerb(tokens[0])){
 		// add item

--- a/src/core/command/Parser.ts
+++ b/src/core/command/Parser.ts
@@ -327,7 +327,7 @@ const parseItemStacks = (tokens: string[], from: number, searchFunc: (word: stri
 
 const parseInteger = (token: string): number|undefined => {
 	if(keywordMatch(token, "all")){
-		return 9999999;
+		return -1;
 	}
 	const num = parseInt(token);
 	if(!Number.isInteger(num)){

--- a/src/surfaces/ReferencePage.tsx
+++ b/src/surfaces/ReferencePage.tsx
@@ -56,7 +56,8 @@ export const ReferencePage: React.FC = React.memo(()=>{
 					<BodyText>
                         This is a list of available commands. All commands and items are case-insensitive
 					</BodyText>
-					<SubHeader>Initialize X item1[meta] Y item2[meta] Z item3[meta] ...</SubHeader>
+					<SubHeader>Initialize</SubHeader>
+					<SubHeader connected>Initialize X item1[meta] Y item2[meta] Z item3[meta] ...</SubHeader>
 					<SubTitle>Used for initializing inventory before simulation</SubTitle>
 					<BodyText>
                         Fully resets the inventory by clearing all items and set Count to 0, then forcefully write the item list to inventory.
@@ -66,6 +67,9 @@ export const ReferencePage: React.FC = React.memo(()=>{
 					<BodyText>
                         If you specify count &gt; 1 for unstackable items like weapon or sheika slate, multiple of that item would be added.
                         Game Data will be synced with Visible Inventory after the reset
+					</BodyText>
+					<BodyText>
+                        If you don't specify any item, it will make an empty inventory
 					</BodyText>
 					<BodyText>
                         Note that this will not clear saves. You can use this command to initialize multiple saves
@@ -220,12 +224,24 @@ export const ReferencePage: React.FC = React.memo(()=>{
 					</p>
 					<p className="Reference Example">Example: Close Game</p>
 
-					<h3 className="Reference">Sync GameData</h3>
-					<h4 className="Reference">Copy Visible Inventory to Game Data</h4>
-					<p className="Reference">
-                        Usually done in game by opening and closing inventory.
-					</p>
-					<p className="Reference Example">Example: Sync GameData</p>
+					<SubHeader>Sync GameData</SubHeader>
+					<SubTitle>Copy Visible Inventory to Game Data</SubTitle>
+					<BodyText>
+                        Certain actions in game will cause gamedata be synced with visible inventory, including but not limited to: open and close inventory, dpad quick menu, drop items.
+					</BodyText>
+					<BodyText>
+                        Furthermore, if visible inventory has Count = 0, Game Data will be empty.
+					</BodyText>
+					<BodyText emphasized>Example: Sync GameData</BodyText>
+
+					<SubHeader>Init GameData</SubHeader>
+					<SubHeader connected>Init GameData X item1[meta] Y item2[meta] Z item3[meta] ...</SubHeader>
+					<SubTitle>Used for forcing the game data to be desynced with visible inventory in simulation</SubTitle>
+					<BodyText>
+                        Similar to <Emphasized>Initialize</Emphasized>, this command sets up game data with items in the specified order. However, this command does not change visible inventory.
+						This can be used to set up an initial state where Game Data is desynced.
+					</BodyText>
+					<BodyText emphasized>Example: Init GameData 1 Apple 2 Axe 3 Slate 4 SpiritOrb</BodyText>
 
 					<h3 className="Reference">Shoot X Arrow</h3>
 					<h4 className="Reference">Simulates shooting arrow without opening inventory</h4>

--- a/src/surfaces/ReferencePage.tsx
+++ b/src/surfaces/ReferencePage.tsx
@@ -29,7 +29,8 @@ export const ReferencePage: React.FC = React.memo(()=>{
 					</BodyText>
 					<SubHeader>Number of Items</SubHeader>
 					<BodyText>
-						When specifying number of items, you can use an integer or <Emphasized>all</Emphasized>, which is equivalent to 9999999 and can be used to remove all items without specifying the real count
+						When specifying number of items, you can use an integer or <Emphasized>all</Emphasized>, which is equivalent to -1.
+						When using -1 as the count in Remove commands, it will remove all items.
 					</BodyText>
 					
 					<SubHeader>Metadata</SubHeader>


### PR DESCRIPTION
- Gamedata is empty if synced with visible inventory when mCount = 0
- using all hangs because of large loop. fixed
- New command `Init GameData` with the same syntax as `Initialize` but only changes game data
- Initialize can now take empty items