### PR TITLE
Drop weapons, bows, and shields instead of reducing durability

### DIFF
--- a/src/__tests__/dropWithExtraLife.e2e.ts
+++ b/src/__tests__/dropWithExtraLife.e2e.ts
@@ -1,0 +1,6 @@
+// Author: jordanbtucker
+const TEST = "dropWithExtraLife";
+it(TEST, () => {
+	expect(TEST).toPassE2ESimulation();
+});
+export { };

--- a/src/__tests__/dropWithExtraLife.in.txt
+++ b/src/__tests__/dropWithExtraLife.in.txt
@@ -1,2 +1,2 @@
-Get 1 Weapon[life=80000] 1 Bow[life=80000] 1 Shield[life=80000]
-Drop 1 Weapon 1 Bow 1 Shield
+Get 1 Weapon[life=80000] 2 Bow[life=80000] 1 Shield 1 Shield[life=80000]
+Drop 1 Weapon 2 Bow 2 Shield

--- a/src/__tests__/dropWithExtraLife.in.txt
+++ b/src/__tests__/dropWithExtraLife.in.txt
@@ -1,0 +1,2 @@
+Get 1 Weapon[life=80000] 1 Bow[life=80000] 1 Shield[life=80000]
+Drop 1 Weapon 1 Bow 1 Shield

--- a/src/core/Slots/Slots.remove.test.ts
+++ b/src/core/Slots/Slots.remove.test.ts
@@ -1,6 +1,6 @@
-import { createMaterialStack, ItemStack } from "data/item";
+import { createEquipmentStack, createMaterialStack, ItemStack, ItemType } from "data/item";
 import { Slots } from "./Slots";
-import { createMaterialMockItem } from "./SlotsTestHelpers";
+import { createEquipmentMockItem, createMaterialMockItem } from "./SlotsTestHelpers";
 
 describe("Slots.remove", ()=>{
 	it("Does nothing if item doesn't exist", ()=>{
@@ -85,6 +85,42 @@ describe("Slots.remove", ()=>{
 		const removed = slots.remove(stackToRemove, 0);
 		const expected: ItemStack[] = [];
 		expect(removed).toBe(2);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes weapons with increased durability", ()=>{
+		const mockItem1 = createEquipmentMockItem("WeaponA", ItemType.Weapon);
+		const stackToRemove = createEquipmentStack(mockItem1, 1000, false);
+
+		const stacks: ItemStack[] = [createEquipmentStack(mockItem1, 80000, false)];
+		const slots = new Slots(stacks);
+
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(1);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes bows with increased durability", ()=>{
+		const mockItem1 = createEquipmentMockItem("WeaponA", ItemType.Bow);
+		const stackToRemove = createEquipmentStack(mockItem1, 1000, false);
+
+		const stacks: ItemStack[] = [createEquipmentStack(mockItem1, 80000, false)];
+		const slots = new Slots(stacks);
+
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(1);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes shields with increased durability", ()=>{
+		const mockItem1 = createEquipmentMockItem("WeaponA", ItemType.Shield);
+		const stackToRemove = createEquipmentStack(mockItem1, 1000, false);
+
+		const stacks: ItemStack[] = [createEquipmentStack(mockItem1, 80000, false)];
+		const slots = new Slots(stacks);
+
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(1);
 		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
 	});
 });

--- a/src/core/Slots/Slots.ts
+++ b/src/core/Slots/Slots.ts
@@ -79,6 +79,12 @@ export class Slots {
 					// find the right slot
 					s++;
 				}else{
+					// fully remove weapons, bows, and shields instead of reducing their life
+					if(stack.item.type === ItemType.Weapon || stack.item.type === ItemType.Bow || stack.item.type === ItemType.Shield){
+						this.internalSlots[i] = stack.modify({count:0});
+						break;
+					}
+
 					if(count<0 || stack.count<count){
 						// this stack not enough to remove all
 						count-=stack.count;


### PR DESCRIPTION
This fixes an issue where weapons, bows, and shields that have increased durability were having their durability values reduced when the `Drop` command was used without specifying its `life` meta value.

For example:

```
Get 1 Weapon[life=80000] 1 Bow[life=80000] 1 Shield[life=80000]
Drop 1 Weapon 1 Bow 1 Shield
```

was resulting in:

```
Initialize 1 Weapon[life=79000] 1 Bow[life=79000] 1 Shield[life=79000]
```

when it should empty the inventory instead.

Tests are included.

Fixes #10