### PR TITLE
Drop non-stackable items regardless of life

### DIFF
--- a/src/__tests__/dropWithExtraLife.in.txt
+++ b/src/__tests__/dropWithExtraLife.in.txt
@@ -1,2 +1,2 @@
-Get 1 Weapon[life=80000] 2 Bow[life=80000] 1 Shield 1 Shield[life=80000]
-Drop 1 Weapon 2 Bow 2 Shield
+Get 1 Weapon[life=80000] 2 Bow[life=80000] 1 Shield 1 Shield[life=80000] 1 HylianHood[life=10] 2 HylianTunic[life=10] 1 HylianTrousers 1 HylianTrousers[life=10]
+Drop 1 Weapon 2 Bow 2 Shield 1 HylianHood 2 HylianTunic 2 HylianTrousers

--- a/src/core/Slots/Slots.remove.test.ts
+++ b/src/core/Slots/Slots.remove.test.ts
@@ -100,7 +100,7 @@ describe("Slots.remove", ()=>{
 		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
 	});
 	it("Removes bows with increased durability", ()=>{
-		const mockItem1 = createEquipmentMockItem("WeaponA", ItemType.Bow);
+		const mockItem1 = createEquipmentMockItem("BowA", ItemType.Bow);
 		const stackToRemove = createEquipmentStack(mockItem1, 1000, false);
 
 		const stacks: ItemStack[] = [createEquipmentStack(mockItem1, 80000, false)];
@@ -112,7 +112,7 @@ describe("Slots.remove", ()=>{
 		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
 	});
 	it("Removes shields with increased durability", ()=>{
-		const mockItem1 = createEquipmentMockItem("WeaponA", ItemType.Shield);
+		const mockItem1 = createEquipmentMockItem("ShieldA", ItemType.Shield);
 		const stackToRemove = createEquipmentStack(mockItem1, 1000, false);
 
 		const stacks: ItemStack[] = [createEquipmentStack(mockItem1, 80000, false)];

--- a/src/core/Slots/Slots.remove.test.ts
+++ b/src/core/Slots/Slots.remove.test.ts
@@ -123,4 +123,40 @@ describe("Slots.remove", ()=>{
 		expect(removed).toBe(1);
 		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
 	});
+	it("Removes upper armor with increased life", ()=>{
+		const mockItem1 = createEquipmentMockItem("ArmorA", ItemType.ArmorUpper);
+		const stackToRemove = createEquipmentStack(mockItem1, 1000, false);
+
+		const stacks: ItemStack[] = [createEquipmentStack(mockItem1, 80000, false)];
+		const slots = new Slots(stacks);
+
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(1);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes middle armor with increased life", ()=>{
+		const mockItem1 = createEquipmentMockItem("ArmorA", ItemType.ArmorMiddle);
+		const stackToRemove = createEquipmentStack(mockItem1, 1000, false);
+
+		const stacks: ItemStack[] = [createEquipmentStack(mockItem1, 80000, false)];
+		const slots = new Slots(stacks);
+
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(1);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
+	it("Removes lower armor with increased life", ()=>{
+		const mockItem1 = createEquipmentMockItem("ArmorA", ItemType.ArmorLower);
+		const stackToRemove = createEquipmentStack(mockItem1, 1000, false);
+
+		const stacks: ItemStack[] = [createEquipmentStack(mockItem1, 80000, false)];
+		const slots = new Slots(stacks);
+
+		const removed = slots.remove(stackToRemove, 0);
+		const expected: ItemStack[] = [];
+		expect(removed).toBe(1);
+		expect(slots.getSlotsRef()).toEqualItemStacks(expected);
+	});
 });

--- a/src/core/Slots/Slots.ts
+++ b/src/core/Slots/Slots.ts
@@ -79,8 +79,9 @@ export class Slots {
 					// find the right slot
 					s++;
 				}else{
-					// fully remove weapons, bows, and shields instead of reducing their life
-					if(stack.item.type === ItemType.Weapon || stack.item.type === ItemType.Bow || stack.item.type === ItemType.Shield){
+					// fully remove non-stackable items like weapons, bows,
+					// shields, and armor instead of reducing their life
+					if(!stack.item.stackable){
 						this.internalSlots[i] = stack.modify({count:0});
 						break;
 					}


### PR DESCRIPTION
Since armor can have a life value, which determines its dye color, a slot containing a dyed armor should be dropped rather than have its life decreased, just like weapons, bows, and shields.

This means that all items not marked as `stackable` should be dropped by the Remove command, regardless of their life values.