### PR TITLE
Set Bow of Light's durability to 100

### DIFF
--- a/src/data/item/all.items.yaml
+++ b/src/data/item/all.items.yaml
@@ -269,7 +269,8 @@ bow:
   global:
     stackable: false
   entries:
-  - BowOfLight
+  - BowOfLight:
+      durability: 100
   - WoodenBow:
       durability: 20
   - TravelersBow:


### PR DESCRIPTION
Although the Bow of Light does not lose durability, it still has a durability value of 100 (`[life=10000]`) which can be transferred to other items.