### PR TITLE
Add reference to reload documentation

### DIFF
--- a/src/surfaces/ReferencePage.tsx
+++ b/src/surfaces/ReferencePage.tsx
@@ -8,6 +8,10 @@ export const ReferencePage: React.FC = React.memo(()=>{
 		<div className="OtherPage">
 			<TitledList title="Command Reference">
 				<div className="OtherPageContent">
+					<Header>Reload Walkthrough</Header>
+          <BodyText>
+            Reloads are the most complex operation within IST and in the Simulator. See <a href="https://restite.org/reload">a detailed explaination</a> of how they work.
+          </BodyText>
 					<Header>Item Syntax</Header>
 					<BodyText>
 						Item are specified by using <Emphasized>search keys</Emphasized> and <Emphasized>metadata</Emphasized>.


### PR DESCRIPTION
Added a link to documentation on how Reload works with all intermediate steps

https://restite.org/reload/

I would be fine moving this documentation link anywhere within the simulator or into the simulator if desired.


